### PR TITLE
feat(training): train clinical model using XGBOOST

### DIFF
--- a/mlops-service/mlops-service/app/components/clinical/model_trainer.py
+++ b/mlops-service/mlops-service/app/components/clinical/model_trainer.py
@@ -1,2 +1,144 @@
+import pickle
+
+import mlflow
+import mlflow.sklearn
+import numpy as np
+import pandas as pd
+from loguru import logger
+from pathlib import Path
+from sklearn.metrics import accuracy_score
+from sklearn.utils.class_weight import compute_sample_weight
+from xgboost import XGBClassifier
+
+from app.entity.config_entity import ClinicalModelTrainerConfig, ClinicalTransformationConfig
+from app.utils.common import read_yaml, save_json
+from app.constants import PARAMS_FILE_PATH, SCHEMA_FILE_PATH
+
+
 class ClinicalModelTrainer:
-    pass
+    def __init__(
+        self,
+        config: ClinicalModelTrainerConfig,
+        transformation_config: ClinicalTransformationConfig,
+    ):
+        self.config = config
+        self.transformation_config = transformation_config
+        self.params = read_yaml(PARAMS_FILE_PATH)
+        self.schema = read_yaml(SCHEMA_FILE_PATH)
+
+    def _load_data(self) -> tuple[pd.DataFrame, pd.DataFrame, int]:
+        train_df = pd.read_csv(self.transformation_config.train_csv)
+        test_df = pd.read_csv(self.transformation_config.test_csv)
+
+        logger.info(f"train samples: {len(train_df)}")
+        logger.info(f"test samples: {len(test_df)}")
+        logger.info(f"features: {[c for c in train_df.columns if c != 'label']}")
+
+        min_label = int(min(train_df["label"].min(), test_df["label"].min()))
+        if min_label != 0:
+            logger.info(f"remapping labels: shifting by -{min_label} to start from 0")
+            train_df["label"] = train_df["label"] - min_label
+            test_df["label"] = test_df["label"] - min_label
+
+        return train_df, test_df, min_label
+
+    def _build_model(self) -> XGBClassifier:
+        xgb_cfg = self.params.ml_training.xgboost
+        p = self.params.ml_training
+        return XGBClassifier(
+            n_estimators=xgb_cfg.n_estimators,
+            max_depth=xgb_cfg.max_depth,
+            learning_rate=xgb_cfg.learning_rate,
+            subsample=xgb_cfg.subsample,
+            colsample_bytree=xgb_cfg.colsample_bytree,
+            eval_metric=xgb_cfg.eval_metric,
+            random_state=p.seed,
+            n_jobs=-1,
+            verbosity=0,
+        )
+
+    def train(self) -> Path:
+        logger.info("=" * 60)
+        logger.info("clinical model training started")
+        logger.info("=" * 60)
+
+        train_df, test_df, label_offset = self._load_data()
+
+        feature_cols = [c for c in train_df.columns if c != "label"]
+        X_train = train_df[feature_cols].values
+        y_train = train_df["label"].values
+        X_test = test_df[feature_cols].values
+        y_test = test_df["label"].values
+
+        sample_weights = compute_sample_weight(class_weight="balanced", y=y_train)
+        logger.info(f"class distribution train: {dict(zip(*np.unique(y_train, return_counts=True)))}")
+        logger.info(f"class distribution test: {dict(zip(*np.unique(y_test, return_counts=True)))}")
+
+        model = self._build_model()
+        xgb_cfg = self.params.ml_training.xgboost
+        p = self.params.ml_training
+
+        with mlflow.start_run(run_name=self.params.get("mlflow", {}).get("clinical_run_name", "xgboost_clinical")):
+            mlflow.log_params({
+                "model": self.config.model_name,
+                "n_estimators": xgb_cfg.n_estimators,
+                "max_depth": xgb_cfg.max_depth,
+                "learning_rate": xgb_cfg.learning_rate,
+                "subsample": xgb_cfg.subsample,
+                "colsample_bytree": xgb_cfg.colsample_bytree,
+                "eval_metric": xgb_cfg.eval_metric,
+                "seed": p.seed,
+                "train_samples": len(train_df),
+                "test_samples": len(test_df),
+                "n_features": len(feature_cols),
+                "label_offset": label_offset,
+            })
+
+            logger.info("fitting XGBoost model with balanced sample weights")
+            model.fit(
+                X_train,
+                y_train,
+                sample_weight=sample_weights,
+                eval_set=[(X_test, y_test)],
+                verbose=False,
+            )
+
+            train_preds = model.predict(X_train)
+            test_preds = model.predict(X_test)
+            train_acc = accuracy_score(y_train, train_preds)
+            test_acc = accuracy_score(y_test, test_preds)
+
+            mlflow.log_metrics({
+                "train_accuracy": round(train_acc, 4),
+                "test_accuracy": round(test_acc, 4),
+            })
+
+            logger.info(f"train accuracy: {train_acc:.4f}")
+            logger.info(f"test accuracy: {test_acc:.4f}")
+
+            feature_importance = dict(zip(feature_cols, model.feature_importances_.tolist()))
+            feature_importance_sorted = dict(
+                sorted(feature_importance.items(), key=lambda x: x[1], reverse=True)
+            )
+            logger.info(f"top features: {list(feature_importance_sorted.keys())[:5]}")
+
+            self.config.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.config.checkpoint_path, "wb") as f:
+                pickle.dump(model, f)
+            logger.info(f"model saved: {self.config.checkpoint_path}")
+
+            save_json(self.config.feature_importance_path, {
+                "feature_importance": feature_importance_sorted,
+                "label_offset": label_offset,
+                "feature_cols": feature_cols,
+            })
+            logger.info(f"feature importance saved: {self.config.feature_importance_path}")
+
+            mlflow.sklearn.log_model(model, name="clinical_model")
+            mlflow.log_artifact(str(self.config.feature_importance_path))
+
+        logger.info("=" * 60)
+        logger.info("clinical model training complete")
+        logger.info("=" * 60)
+
+        return self.config.checkpoint_path

--- a/mlops-service/mlops-service/app/config/configuration.py
+++ b/mlops-service/mlops-service/app/config/configuration.py
@@ -91,10 +91,12 @@ class ConfigurationManager:
 
     def get_clinical_ingestion_config(self) -> ClinicalIngestionConfig:
         cfg = self.config.data_ingestion.samaya
+        trans_cfg = self.config.data_transformation.clinical
         return ClinicalIngestionConfig(
             reports_csv=Path(cfg.reports_csv),
             reports_json=Path(cfg.reports_json),
             images_dir=Path(cfg.images_dir),
+            raw_csv=Path(trans_cfg.raw_csv),
         )
 
     def get_clinical_cleaning_config(self) -> ClinicalCleaningConfig:

--- a/mlops-service/mlops-service/app/entity/config_entity.py
+++ b/mlops-service/mlops-service/app/entity/config_entity.py
@@ -52,6 +52,7 @@ class ClinicalIngestionConfig:
     reports_csv: Path
     reports_json: Path
     images_dir: Path
+    raw_csv: Path
 
 
 @dataclass(frozen=True)

--- a/mlops-service/mlops-service/app/pipeline/clinical/stage_02_data_cleaning.py
+++ b/mlops-service/mlops-service/app/pipeline/clinical/stage_02_data_cleaning.py
@@ -1,15 +1,16 @@
 from loguru import logger
-from app.config.configuration import ConfigurationManager
-from app.components.clinical.data_ingestion import ClinicalDataIngestion
+
 from app.components.clinical.data_cleaning import ClinicalDataCleaning
+from app.config.configuration import ConfigurationManager
+
+STAGE_NAME = "Clinical Data Cleaning"
 
 
 def run():
-    logger.info(">>> stage 02: clinical data cleaning started")
+    logger.info(f">>> stage 02: {STAGE_NAME} started")
     manager = ConfigurationManager()
-    df = ClinicalDataIngestion(manager.get_clinical_ingestion_config()).run()
-    ClinicalDataCleaning(manager.get_clinical_cleaning_config()).run(df)
-    logger.info(">>> stage 02: clinical data cleaning complete")
+    ClinicalDataCleaning(manager.get_clinical_cleaning_config()).run()
+    logger.info(f">>> stage 02: {STAGE_NAME} complete")
 
 
 if __name__ == "__main__":

--- a/mlops-service/mlops-service/app/pipeline/clinical/stage_03_data_transformation.py
+++ b/mlops-service/mlops-service/app/pipeline/clinical/stage_03_data_transformation.py
@@ -1,17 +1,18 @@
 from loguru import logger
-from app.config.configuration import ConfigurationManager
-from app.components.clinical.data_ingestion import ClinicalDataIngestion
+
 from app.components.clinical.data_cleaning import ClinicalDataCleaning
 from app.components.clinical.data_transformation import ClinicalDataTransformation
+from app.config.configuration import ConfigurationManager
+
+STAGE_NAME = "Clinical Data Transformation"
 
 
 def run():
-    logger.info(">>> stage 03: clinical data transformation started")
+    logger.info(f">>> stage 03: {STAGE_NAME} started")
     manager = ConfigurationManager()
-    df = ClinicalDataIngestion(manager.get_clinical_ingestion_config()).run()
-    df = ClinicalDataCleaning(manager.get_clinical_cleaning_config()).run(df)
-    ClinicalDataTransformation(manager.get_clinical_transformation_config()).run(df)
-    logger.info(">>> stage 03: clinical data transformation complete")
+    ClinicalDataCleaning(manager.get_clinical_cleaning_config()).run()
+    ClinicalDataTransformation(manager.get_clinical_transformation_config()).run()
+    logger.info(f">>> stage 03: {STAGE_NAME} complete")
 
 
 if __name__ == "__main__":

--- a/mlops-service/mlops-service/app/pipeline/clinical/stage_04_model_trainer.py
+++ b/mlops-service/mlops-service/app/pipeline/clinical/stage_04_model_trainer.py
@@ -1,15 +1,19 @@
 from loguru import logger
-from app.config.configuration import ConfigurationManager
+
 from app.components.clinical.model_trainer import ClinicalModelTrainer
+from app.config.configuration import ConfigurationManager
+
+STAGE_NAME = "Clinical Model Training"
 
 
 def run():
-    logger.info(">>> stage 04: clinical model training started")
+    logger.info(f">>> stage 04: {STAGE_NAME} started")
     manager = ConfigurationManager()
-    cfg = manager.get_clinical_model_trainer_config()
-    transformation_cfg = manager.get_clinical_transformation_config()
-    ClinicalModelTrainer(cfg, transformation_cfg).train()
-    logger.info(">>> stage 04: clinical model training complete")
+    ClinicalModelTrainer(
+        manager.get_clinical_model_trainer_config(),
+        manager.get_clinical_transformation_config(),
+    ).train()
+    logger.info(f">>> stage 04: {STAGE_NAME} complete")
 
 
 if __name__ == "__main__":

--- a/mlops-service/mlops-service/config/config.yaml
+++ b/mlops-service/mlops-service/config/config.yaml
@@ -20,6 +20,7 @@ data_transformation:
     samaya_csv: artifacts/data/processed/imaging/samaya.csv
   clinical:
     root_dir: artifacts/data/processed/clinical
+    raw_csv: artifacts/data/processed/clinical/raw.csv
     train_csv: artifacts/data/processed/clinical/train.csv
     test_csv: artifacts/data/processed/clinical/test.csv
     feature_file: artifacts/data/processed/clinical/features.json

--- a/mlops-service/requirements.txt
+++ b/mlops-service/requirements.txt
@@ -10,6 +10,7 @@ numpy>=1.25
 scikit-learn>=1.3
 seaborn>=0.12
 matplotlib>=3.7
+xgboost>=2.0.0
 
 Pillow>=10.0
 opencv-python-headless>=4.8
@@ -35,3 +36,4 @@ httpx>=0.27.0
 pytest>=8.0
 pytest-asyncio>=0.23
 pytesseract>=0.3.10
+


### PR DESCRIPTION
## Summary by Sourcery

Add an end-to-end clinical model training stage using XGBoost and integrate it into the clinical data pipeline.

New Features:
- Introduce a ClinicalModelTrainer component that trains an XGBoost classifier on processed clinical data, logs metrics to MLflow, and persists the trained model and feature importance artifacts.

Enhancements:
- Refine clinical pipeline stages to decouple data ingestion, cleaning, and transformation, and standardize stage logging names.
- Extend clinical ingestion configuration to include a raw CSV output path for downstream processing.
- Wire configuration and schema parameters into the clinical training flow for consistent feature and label handling.

Build:
- Add xgboost to the service Python dependencies.