### PR TITLE
test: add shared fixtures and PR test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,113 @@
+name: Test Suite
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend-service/**'
+      - 'mlops-service/**'
+      - 'llmops-service/**'
+      - '.github/workflows/tests.yml'
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: backend-service/requirements.txt
+
+      - name: Install dependencies
+        working-directory: backend-service
+        run: pip install -r requirements.txt
+
+      - name: Create test env file
+        working-directory: backend-service/backend-service
+        run: |
+          cat > .env << EOF
+          APP_ENV=development
+          APP_NAME=retinaxai-backend
+          DATABASE_URL=postgresql+asyncpg://test:test@localhost:5432/test_db
+          SECRET_KEY=test-secret-key
+          ML_SERVICE_URL=http://localhost:8001
+          ML_SERVICE_API_KEY=test-api-key
+          LLM_SERVICE_URL=http://localhost:8002
+          LLM_SERVICE_API_KEY=test-api-key
+          EOF
+
+      - name: Run tests
+        working-directory: backend-service/backend-service
+        run: pytest tests/ -v --tb=short
+
+  mlops:
+    name: MLOps Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: mlops-service/requirements-ci.txt
+
+      - name: Install CI dependencies
+        working-directory: mlops-service
+        run: pip install -r requirements-ci.txt && pip install --no-deps -e .
+
+      - name: Create test env file
+        working-directory: mlops-service/mlops-service
+        run: |
+          cat > .env << EOF
+          APP_ENV=development
+          APP_NAME=retinaxai-mlops
+          MLFLOW_TRACKING_URI=http://localhost:5000
+          EOF
+
+      - name: Run tests
+        working-directory: mlops-service/mlops-service
+        run: pytest tests/ -v --tb=short
+
+  llmops:
+    name: LLMOps Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: llmops-service/requirements-ci.txt
+
+      - name: Install CI dependencies
+        working-directory: llmops-service
+        run: pip install -r requirements-ci.txt
+
+      - name: Create test env file
+        working-directory: llmops-service/llmops-service
+        run: |
+          cat > .env << EOF
+          APP_ENV=development
+          APP_NAME=retinaxai-llmops
+          LLM_PROVIDER=mock
+          LLM_MODEL=mock-model
+          EOF
+
+      - name: Run tests
+        working-directory: llmops-service/llmops-service
+        run: pytest tests/ -v --tb=short

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,11 +60,11 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-          cache-dependency-path: mlops-service/requirements-ci.txt
+          cache-dependency-path: mlops-service/requirements.txt
 
-      - name: Install CI dependencies
+      - name: Install dependencies
         working-directory: mlops-service
-        run: pip install -r requirements-ci.txt && pip install --no-deps -e .
+        run: pip install -r requirements.txt && pip install --no-deps -e .
 
       - name: Create test env file
         working-directory: mlops-service/mlops-service

--- a/backend-service/backend-service/tests/conftest.py
+++ b/backend-service/backend-service/tests/conftest.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.auth.jwt_handler import create_access_token, create_refresh_token
+
+
+@pytest.fixture
+def user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def access_token(user_id: uuid.UUID) -> str:
+    return create_access_token(user_id)
+
+
+@pytest.fixture
+def refresh_token(user_id: uuid.UUID) -> str:
+    return create_refresh_token(user_id)
+
+
+@pytest.fixture
+def auth_db_session() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def auth_session(user_id: uuid.UUID) -> SimpleNamespace:
+    return SimpleNamespace(
+        revoked=False,
+        user_id=user_id,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+    )
+
+
+@pytest.fixture
+def api_client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def report_generate_payload() -> dict[str, str]:
+    return {"prediction_id": str(uuid.uuid4())}
+
+
+@pytest.fixture
+def llm_report_payload() -> dict[str, object]:
+    return {
+        "patient": {"patient_id": str(uuid.uuid4()), "age": 70, "gender": "M"},
+        "prediction": {"label": "mild", "confidence": 0.93},
+        "cleaned_summary": "Mild non-proliferative diabetic retinopathy.",
+        "raw_ocr_text": "raw ocr text",
+        "report_type": "report",
+        "language": "en",
+        "tone": "clinical",
+        "model_name": "gpt-4.1-mini",
+        "model_version": "2026-04-01",
+        "prediction_output": {"label": "mild"},
+        "confidence_score": 0.93,
+    }
+
+
+@pytest.fixture
+def user_create_payload() -> dict[str, str]:
+    return {
+        "email": "patient@example.com",
+        "username": "patient_one",
+        "password": "secret123",
+    }
+
+
+@pytest.fixture
+def patient_create_payload() -> dict[str, object]:
+    return {
+        "first_name": "Louay",
+        "last_name": "Hassan",
+        "age": 70,
+        "gender": "M",
+        "phone": "+15550000000",
+        "address": "123 Main St",
+        "medical_record_number": "MRN-001",
+        "ocr_patient_id": "ocr-001",
+    }
+
+
+@pytest.fixture
+def prediction_request_payload(user_id: uuid.UUID) -> dict[str, object]:
+    return {
+        "patient_id": str(uuid.uuid4()),
+        "mri_scan_id": str(uuid.uuid4()),
+        "model_name": "retina-cnn",
+        "model_version": "1.0.0",
+        "input_payload": {"image_path": "/tmp/scan.png", "user_id": str(user_id)},
+    }

--- a/backend-service/backend-service/tests/conftest.py
+++ b/backend-service/backend-service/tests/conftest.py
@@ -5,8 +5,9 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
-from fastapi.testclient import TestClient
+import pytest_asyncio
 
 from app.main import app
 from app.auth.jwt_handler import create_access_token, create_refresh_token
@@ -41,9 +42,10 @@ def auth_session(user_id: uuid.UUID) -> SimpleNamespace:
     )
 
 
-@pytest.fixture
-def api_client() -> TestClient:
-    return TestClient(app)
+@pytest_asyncio.fixture
+async def api_client() -> httpx.AsyncClient:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://testserver") as client:
+        yield client
 
 
 @pytest.fixture

--- a/backend-service/backend-service/tests/integration/test_report_route.py
+++ b/backend-service/backend-service/tests/integration/test_report_route.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.report_schema import ReportGenerateRequest
+
+
+def test_shared_report_fixture_matches_schema(report_generate_payload) -> None:
+    data = ReportGenerateRequest.model_validate(report_generate_payload)
+
+    assert data.prediction_id is not None
+
+
+def test_shared_llm_payload_has_required_fields(llm_report_payload) -> None:
+    assert llm_report_payload["patient"]
+    assert llm_report_payload["cleaned_summary"]
+    assert llm_report_payload["raw_ocr_text"]
+
+
+@pytest.mark.asyncio
+async def test_api_client_fixture_available(api_client) -> None:
+    response = api_client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/backend-service/backend-service/tests/integration/test_report_route.py
+++ b/backend-service/backend-service/tests/integration/test_report_route.py
@@ -19,7 +19,7 @@ def test_shared_llm_payload_has_required_fields(llm_report_payload) -> None:
 
 @pytest.mark.asyncio
 async def test_api_client_fixture_available(api_client) -> None:
-    response = api_client.get("/health")
+    response = await api_client.get("/health")
 
     assert response.status_code == 200
     assert response.json()["status"] == "ok"

--- a/backend-service/backend-service/tests/unit/test_auth.py
+++ b/backend-service/backend-service/tests/unit/test_auth.py
@@ -1,49 +1,40 @@
-import uuid
 from unittest.mock import AsyncMock
 
 import pytest
 
 from app.api.v1.routes.auth_routes import RefreshRequest, refresh_token
-from app.auth.jwt_handler import create_access_token, create_refresh_token, decode_token
+from app.auth.jwt_handler import decode_token
 from app.auth.session_service import AuthSessionService
 from app.core.exceptions import UnauthorizedException
 
 
-def test_create_access_token_marks_type_access() -> None:
-    token = create_access_token(uuid.uuid4())
-    payload = decode_token(token)
+def test_create_access_token_marks_type_access(access_token: str) -> None:
+    payload = decode_token(access_token)
 
     assert payload.token_type == "access"
 
 
-def test_create_refresh_token_marks_type_refresh() -> None:
-    token = create_refresh_token(uuid.uuid4())
-    payload = decode_token(token)
+def test_create_refresh_token_marks_type_refresh(refresh_token: str) -> None:
+    payload = decode_token(refresh_token)
 
     assert payload.token_type == "refresh"
 
 
 @pytest.mark.asyncio
-async def test_refresh_rejects_access_token() -> None:
-    db_session = AsyncMock()
-    token = create_access_token(uuid.uuid4())
-
+async def test_refresh_rejects_access_token(access_token: str, auth_db_session) -> None:
     with pytest.raises(UnauthorizedException):
-        await refresh_token(RefreshRequest(refresh_token=token), db_session)
+        await refresh_token(RefreshRequest(refresh_token=access_token), auth_db_session)
 
 
 @pytest.mark.asyncio
-async def test_logout_marks_session_revoked() -> None:
-    db_session = AsyncMock()
-    session_service = AuthSessionService(db_session)
-    refresh = create_refresh_token(uuid.uuid4())
+async def test_logout_marks_session_revoked(auth_db_session, auth_session, refresh_token: str) -> None:
+    session_service = AuthSessionService(auth_db_session)
 
-    session = _Session()
-    db_session.execute = AsyncMock(return_value=_result(session))
-    db_session.flush = AsyncMock()
+    auth_db_session.execute = AsyncMock(return_value=_result(auth_session))
+    auth_db_session.flush = AsyncMock()
 
-    await session_service.revoke_refresh_token(refresh)
-    assert session.revoked is True
+    await session_service.revoke_refresh_token(refresh_token)
+    assert auth_session.revoked is True
 
 
 class _result:
@@ -52,12 +43,3 @@ class _result:
 
     def scalar_one_or_none(self):
         return self.obj
-
-
-class _Session:
-    def __init__(self) -> None:
-        from datetime import datetime, timedelta, timezone
-
-        self.revoked = False
-        self.user_id = uuid.uuid4()
-        self.expires_at = datetime.now(timezone.utc) + timedelta(days=1)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,106 @@
+# RetinaXAI Remaining Plan
+
+## LLMOps
+
+### #1 Add RAG ingestion pipeline with offline/online separation
+- Add an offline ingestion job that builds or updates the vector store from approved source documents.
+- Add an online retrieval path for report generation.
+- Keep ingestion and serving separate.
+- Expose FastAPI endpoints for reindex/status if needed.
+- Add tests for chunking, embeddings, retrieval, and prompt assembly.
+
+## Observability
+
+### #12 Observability: Integrate Metrics & Tracing
+- Add Prometheus counters/histograms for request counts, latency, and failures.
+- Add OpenTelemetry traces across backend, mlops, and llmops request paths.
+- Export metrics and traces from service startup.
+- Add health/readiness endpoints where missing.
+- Add tests for metric registration and tracing startup.
+
+### #40 Add OpenTelemetry tracing setup
+- Add tracing middleware/instrumentation to the backend FastAPI app.
+- Add span propagation for service-to-service HTTP calls.
+- Configure the exporter through env vars.
+- Make tracing work locally without production-only infrastructure.
+- Add a smoke test for tracer initialization.
+
+## QA / Testing
+
+### #13 QA: Write Unit & Integration Test Suite
+- Fill missing unit tests for backend services and API routes.
+- Add integration tests for the main request flows.
+- Add shared fixtures for DB/session/client mocking.
+- Run lint and tests in CI for all services.
+- Document test data and env setup.
+
+### #41 Add shared pytest fixtures
+- Done: shared fixtures added in backend and MLOps `tests/conftest.py`.
+- Added fixtures for auth/session, API client, temp dirs, and sample payloads.
+- Reused the fixtures in backend auth/report tests and MLOps OCR pipeline tests.
+
+### #90 Pytest fixtures for config and dataset mocks
+- Add fixtures for config objects, temp paths, and synthetic datasets.
+- Mock external services once in a shared location.
+- Reuse the fixtures across OCR and training tests.
+- Keep fixture names stable and descriptive.
+
+### #91 Unit tests for data ingestion
+- Test ingestion stage entrypoints.
+- Verify dataset download/copy/skip logic.
+- Mock file system and remote dataset access.
+- Assert expected output paths and logs.
+
+### #92 Unit tests for preprocessing
+- Test preprocessing transforms on sample inputs.
+- Cover empty, malformed, and low-quality inputs.
+- Assert output schema, shape, and saved artifacts.
+- Mock image and file I/O.
+
+### #93 Unit tests for model trainer
+- Test model initialization and config wiring.
+- Verify logging, checkpointing, and early stopping.
+- Mock the training loop to keep tests fast.
+- Assert MLflow logging calls and artifact paths.
+
+### #122 Unit tests for ML trainer and feature engineering
+- Add tests for structured feature engineering outputs.
+- Verify the trainer consumes engineered features correctly.
+- Cover feature importance, label mapping, and artifact export.
+- Mock fit/predict to keep tests fast.
+
+## Frontend
+
+### #53 Reconfigure sidebar nav and rewire overview dashboard
+- Update navigation to match current backend, mlops, and llmops routes.
+- Remove dead links and show only working pages.
+- Make the overview dashboard show real service status and latest results.
+- Ensure sidebar labels match the current product areas.
+- Add UI tests or snapshots for nav rendering.
+
+### #54 Build patient management pages
+- Build the patient list page from backend `/patients`.
+- Add a patient detail view with predictions, reports, and scans.
+- Add the scan upload flow tied to backend ingestion.
+- Handle empty, loading, and error states.
+- Add route guards and permissions.
+
+### #55 Build predictions and Grad-CAM pages
+- Build predictions list/detail pages.
+- Add Grad-CAM visualization display from backend or MLOps outputs.
+- Show model metadata, confidence, and explanation artifacts.
+- Handle missing artifacts cleanly.
+- Add UI tests for rendered data.
+
+### #56 Build LLM reports and model monitoring pages
+- Build a report list/detail page for generated LLM outputs.
+- Add a model monitoring page for drift/performance metrics.
+- Pull metrics from backend or MLOps endpoints, not local files.
+- Show report generation status and history.
+- Add loading, error, and empty states.
+
+## Infra / Project Hygiene
+
+- Keep service-local `data/` directories ignored in git.
+- Keep docs and templates aligned with actual directory layouts.
+- Prefer env-backed paths and service-to-service API calls over shared filesystem coupling.

--- a/mlops-service/mlops-service/tests/conftest.py
+++ b/mlops-service/mlops-service/tests/conftest.py
@@ -1,9 +1,13 @@
-import pytest
+from __future__ import annotations
+
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 
 @pytest.fixture
-def sample_text():
+def sample_text() -> str:
     return """
     3D Macula Report    Triton    Print Date: 15/03/2026 11:10:55
     ID: 849x    Gender: Male    DOB: 01/01/1956    Age: 70
@@ -20,5 +24,26 @@ def sample_text():
 
 
 @pytest.fixture
-def dummy_image():
+def dummy_image() -> np.ndarray:
     return np.zeros((1000, 1280, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def temp_input_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "input"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def temp_output_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "output"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def temp_images_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "images"
+    path.mkdir()
+    return path

--- a/mlops-service/mlops-service/tests/conftest.py
+++ b/mlops-service/mlops-service/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import yaml
 
 
 @pytest.fixture
@@ -47,3 +48,11 @@ def temp_images_dir(tmp_path: Path) -> Path:
     path = tmp_path / "images"
     path.mkdir()
     return path
+
+
+@pytest.fixture
+def regions_config() -> dict:
+    config_path = Path(__file__).resolve().parents[1] / "config" / "regions.yaml"
+    with config_path.open() as f:
+        data = yaml.safe_load(f)
+    return data.get("regions", data)

--- a/mlops-service/mlops-service/tests/ocr/test_region_detector.py
+++ b/mlops-service/mlops-service/tests/ocr/test_region_detector.py
@@ -1,20 +1,9 @@
 import numpy as np
-import yaml
-from pathlib import Path
 from app.components.ocr.region_detector import extract_regions
 
-REGIONS_CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "regions.yaml"
 
-def _load_config():
-    with open(REGIONS_CONFIG_PATH) as f:
-        data = yaml.safe_load(f)
-        return data.get("regions", data)
-
-REGIONS_CONFIG = _load_config()
-
-
-def test_extract_regions_keys(dummy_image):
-    crops = extract_regions(dummy_image, REGIONS_CONFIG)
+def test_extract_regions_keys(dummy_image, regions_config):
+    crops = extract_regions(dummy_image, regions_config)
     expected = {
         "fundus_infrared", "oct_bscan_horizontal", "etdrs_heatmap",
         "shadowgram", "retinal_thickness_map", "oct_bscan_vertical",
@@ -23,13 +12,13 @@ def test_extract_regions_keys(dummy_image):
     assert set(crops.keys()) == expected
 
 
-def test_extract_regions_nonzero(dummy_image):
-    crops = extract_regions(dummy_image, REGIONS_CONFIG)
+def test_extract_regions_nonzero(dummy_image, regions_config):
+    crops = extract_regions(dummy_image, regions_config)
     for name, crop in crops.items():
         assert crop.size > 0, f"Empty crop: {name}"
 
 
-def test_extract_regions_are_numpy_arrays(dummy_image):
-    crops = extract_regions(dummy_image, REGIONS_CONFIG)
+def test_extract_regions_are_numpy_arrays(dummy_image, regions_config):
+    crops = extract_regions(dummy_image, regions_config)
     for name, crop in crops.items():
         assert isinstance(crop, np.ndarray), f"Not ndarray: {name}"

--- a/mlops-service/mlops-service/tests/test_ocr_pipeline.py
+++ b/mlops-service/mlops-service/tests/test_ocr_pipeline.py
@@ -2,26 +2,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 from app.entity.ocr_schema import ClinicalFindings, OCTReport, PatientInfo, RegionImage, ReportMetadata, RetinalThickness
 from app.pipeline.ocr_pipeline import OCRPipeline
 
 
-def test_ocr_pipeline_export_uses_configured_paths(monkeypatch, tmp_path):
-    input_dir = tmp_path / "ocr_reports"
-    output_dir = tmp_path / "output"
-    images_dir = tmp_path / "images"
+def test_ocr_pipeline_export_uses_configured_paths(monkeypatch, temp_input_dir, temp_output_dir, temp_images_dir):
+    input_dir = temp_input_dir
+    output_dir = temp_output_dir
+    images_dir = temp_images_dir
     regions_config = {"fundus": {"rel": [0.0, 0.0, 1.0, 1.0]}}
 
-    class DummyConfig:
-        pass
-
-    DummyConfig.input_dir = input_dir
-    DummyConfig.output_dir = output_dir
-    DummyConfig.json_output = output_dir / "reports.json"
-    DummyConfig.csv_output = output_dir / "reports.csv"
-    DummyConfig.images_dir = images_dir
-    DummyConfig.regions_config = regions_config
+    DummyConfig = SimpleNamespace(
+        input_dir=input_dir,
+        output_dir=output_dir,
+        json_output=output_dir / "reports.json",
+        csv_output=output_dir / "reports.csv",
+        images_dir=images_dir,
+        regions_config=regions_config,
+    )
 
     report = OCTReport(
         source_file="scan.jpg",
@@ -34,8 +35,8 @@ def test_ocr_pipeline_export_uses_configured_paths(monkeypatch, tmp_path):
         extraction_warnings=[],
     )
 
-    pipeline = OCRPipeline.__new__(OCRPipeline)
-    pipeline.config = DummyConfig()
+    pipeline = cast(Any, OCRPipeline.__new__(OCRPipeline))
+    pipeline.config = DummyConfig
 
     captured: dict[str, object] = {}
 
@@ -51,25 +52,21 @@ def test_ocr_pipeline_export_uses_configured_paths(monkeypatch, tmp_path):
 
     pipeline._export([report])
 
-    assert captured["json"][0]["source_file"] == "scan.jpg"
+    assert cast(list[dict[str, object]], captured["json"])[0]["source_file"] == "scan.jpg"
     assert captured["csv_path"] == str(DummyConfig.csv_output)
     assert captured["csv_index"] is False
 
 
-def test_ocr_pipeline_skips_existing_report(monkeypatch, tmp_path):
-    pipeline = OCRPipeline.__new__(OCRPipeline)
-    pipeline.config = type(
-        "Cfg",
-        (),
-        {
-            "images_dir": tmp_path / "images",
-            "input_dir": tmp_path / "input",
-            "regions_config": {},
-            "output_dir": tmp_path / "output",
-            "json_output": tmp_path / "output" / "reports.json",
-            "csv_output": tmp_path / "output" / "reports.csv",
-        },
-    )()
+def test_ocr_pipeline_skips_existing_report(monkeypatch, temp_input_dir, temp_output_dir, temp_images_dir):
+    pipeline = cast(Any, OCRPipeline.__new__(OCRPipeline))
+    pipeline.config = SimpleNamespace(
+        images_dir=temp_images_dir,
+        input_dir=temp_input_dir,
+        regions_config={},
+        output_dir=temp_output_dir,
+        json_output=temp_output_dir / "reports.json",
+        csv_output=temp_output_dir / "reports.csv",
+    )
 
     report_dir = pipeline.config.images_dir / "patient" / "OD" / "scan"
     report_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Add shared pytest fixtures for backend auth/report tests and MLOps OCR tests.
- Reuse the fixtures in real tests and add a PR-only GitHub Actions test workflow.
- Mark issue #41 as complete in the plan doc.

## Verification
- `backend-service/.venv/bin/python -m pytest backend-service/backend-service/tests/unit/test_auth.py backend-service/backend-service/tests/integration/test_report_route.py`
- `mlops-service/.venv/bin/python -m pytest mlops-service/mlops-service/tests/ocr`